### PR TITLE
Add option to skip building the themisto index & installation instructions for some dependencies using conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,32 @@ This pipeline assess the demixed binned reads from an mGEMS analysis to help wit
 * mash
 * seqtk
 
+## Installation
+
+The following depdendencies can be installed using conda
+
+* python3 with numpy and pandas
+* R with tidyverse and cowplot (for plotting)
+* mash
+* seqtk
+
+with the commands
+
+```
+conda create -n demix_check
+conda activate demix_check
+conda install -c anaconda -c bioconda -c conda-forge numpy pandas seqtk mash r-tidyverse r-cowplot
+```
+
+The following dependencies need to be installed according to the
+instructions in their repositories:
+
+```
+* build_index and pseudoalign (from [themisto](https://github.com/algbio/themisto/))
+* [mSWEEP](https://github.com/PROBIC/mSWEEP)
+* [mGEMS](https://github.com/PROBIC/mGEMS)
+```
+
 ## Running the pipeline
 
 Clone the repository with:

--- a/README.md
+++ b/README.md
@@ -32,11 +32,9 @@ conda install -c anaconda -c bioconda -c conda-forge numpy pandas seqtk mash r-t
 The following dependencies need to be installed according to the
 instructions in their repositories:
 
-```
 * build_index and pseudoalign (from [themisto](https://github.com/algbio/themisto/))
 * [mSWEEP](https://github.com/PROBIC/mSWEEP)
 * [mGEMS](https://github.com/PROBIC/mGEMS)
-```
 
 ## Running the pipeline
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ with the commands
 ```
 conda create -n demix_check
 conda activate demix_check
-conda install -c anaconda -c bioconda -c conda-forge numpy pandas seqtk mash r-tidyverse r-cowplot
+conda install -y -c anaconda -c conda-forge -c bioconda numpy=1.21.4 pandas=1.3.4 seqtk=1.3 mash=2.3 r-tidyverse=1.3.1 r-cowplot=1.1.1
 ```
 
 The following dependencies need to be installed according to the

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Run arguments:
 
   --r1 R1               r1 file
   --r2 R2               r2 file
-
+  --themisto_index THEMISTO_INDEX
+                        path to the themisto index directory [default = ref_idx in --ref]
 General arguments:
   --out_dir OUT_DIR     output directory
   --ref REF             reference set/s to use [either a string specifying the path to the reference directory or a file containing paths to the reference directories]
@@ -98,8 +99,6 @@ General arguments:
   --threads THREADS     number of threads to use [default = 1]
   --keep                keep large intermediate files [default = off]
   -h, --help            show this help message and exit
-  --themisto_index THEMISTO_INDEX
-                        path to the themisto index directory [default = ref_idx in --ref]
 ```
 
 ## Modes

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Setup arguments:
                         proportion of median divergence between clusters to set minimum threshold to [default = 0.2]
   --thr_abs_min  THR_ABS_MIN
                         absolute minimum threshold [default = not set] [overrides --thr_prop_min]
+  --no_build_index      Skip building the themisto index [default = False]
 
 Check arguments:
   Arguments for check mode
@@ -73,6 +74,8 @@ General arguments:
   --threads THREADS     number of threads to use [default = 1]
   --keep                keep large intermediate files [default = off]
   -h, --help            show this help message and exit
+  --themisto_index THEMISTO_INDEX
+                        path to the themisto index directory [default = ref_idx in --ref]
 ```
 
 ## Modes

--- a/check_assignments.py
+++ b/check_assignments.py
@@ -10,10 +10,9 @@ import numpy as np
 
 from sketch import *
 
-def check_mGEMS(mash_exec, seqtk_exec, t, ss, min_abun, ref_d, out_d, binned_reads_d, msweep_abun, themisto_index):
+def check_mGEMS(mash_exec, seqtk_exec, t, ss, min_abun, ref_d, out_d, binned_reads_d, msweep_abun):
     sys.stderr.write("Checking analysis {} against reference set {}...\n".format(binned_reads_d, ref_d))
 
-    ref_idx=themisto_index
     ref_clu="{}/ref_clu.tsv".format(ref_d)
     ref=os.path.basename(ref_d)
     out=os.path.basename(out_d)

--- a/check_assignments.py
+++ b/check_assignments.py
@@ -10,10 +10,10 @@ import numpy as np
 
 from sketch import *
 
-def check_mGEMS(mash_exec, seqtk_exec, t, ss, min_abun, ref_d, out_d, binned_reads_d, msweep_abun):
+def check_mGEMS(mash_exec, seqtk_exec, t, ss, min_abun, ref_d, out_d, binned_reads_d, msweep_abun, themisto_index):
     sys.stderr.write("Checking analysis {} against reference set {}...\n".format(binned_reads_d, ref_d))
 
-    ref_idx="{}/ref_idx".format(ref_d)
+    ref_idx=themisto_index
     ref_clu="{}/ref_clu.tsv".format(ref_d)
     ref=os.path.basename(ref_d)
     out=os.path.basename(out_d)

--- a/demix_check.py
+++ b/demix_check.py
@@ -65,7 +65,7 @@ general_group.add_argument('--plots', action="store_true", default=False, help='
 general_group.add_argument('--threads', type=int, default=1, help='number of threads to use [default = %(default)d]')
 general_group.add_argument('--keep', action="store_true", default=False, help='keep large intermediate files [default = off]')
 general_group.add_argument('-h', '--help', action='help', help="show this help message and exit")
-general_group.add_argument('--themisto_index', type=str, required='--mode_check' in sys.argv, help='path to the themisto index directory [default = ref_idx in --ref]')
+general_group.add_argument('--themisto_index', type=str, help='path to the themisto index directory [default = ref_idx in --ref]')
 
 # set up arg vars
 args=parser.parse_args()

--- a/demix_check.py
+++ b/demix_check.py
@@ -44,6 +44,7 @@ setup_group.add_argument('--thr_prop_exp', type=float, default=0.2, help='propor
 setup_group.add_argument('--thr_prop_min', type=float, default=0.2, help='proportion of median divergence between clusters to set minimum threshold to [default = %(default)s]')
 setup_group.add_argument('--thr_abs_min', type=float, help='absolute minimum threshold [default = not set] [overrides --thr_prop_min]')
 setup_group.add_argument('--no_build_index', action="store_true", default=False, help='Skip building the themisto index [default = %(default)s]')
+setup_group.add_argument('--no_build_fasta', action="store_true", default=False, help='Skip building the fasta file for the themisto index [default = %(default)s]')
 
 # args specific to check mode
 check_group=parser.add_argument_group('Check arguments', 'Arguments for check mode')
@@ -79,6 +80,7 @@ thr_prop_exp=args.thr_prop_exp
 thr_prop_min=args.thr_prop_min
 thr_abs_min=args.thr_abs_min
 no_build_index=args.no_build_index
+no_build_fasta=args.no_build_fasta
 
 binned_reads_d=args.binned_reads_dir
 msweep_abun=args.msweep_abun
@@ -146,7 +148,7 @@ if mode_setup:
     for ref_d in ref_ds:
         if os.path.isdir(ref_d) and os.path.isfile("{}/ref_info.tsv".format(ref_d)):
             
-            setup_reference(mash_exec, themisto_build_exec, seqtk_exec, ref_d, t, ss, thr_prop_min, thr_abs_min, thr_prop_exp, redo_thr, no_build_index)
+            setup_reference(mash_exec, themisto_build_exec, seqtk_exec, ref_d, t, ss, thr_prop_min, thr_abs_min, thr_prop_exp, redo_thr, no_build_index, no_build_fasta)
             
             if plots:
                 sys.stderr.write("Plotting output...\n")

--- a/demix_check.py
+++ b/demix_check.py
@@ -54,6 +54,7 @@ check_group.add_argument('--msweep_abun', type=str, required='--mode_check' in s
 run_group=parser.add_argument_group('Run arguments', 'Arguments for run mode')
 run_group.add_argument('--r1', type=str, required='--mode_run' in sys.argv, help='r1 file')
 run_group.add_argument('--r2', type=str, required='--mode_run' in sys.argv, help='r2 file')
+run_group.add_argument('--themisto_index', type=str, help='path to the themisto index directory [default = ref_idx in --ref]')
 
 # general args
 general_group=parser.add_argument_group('General arguments')
@@ -65,7 +66,6 @@ general_group.add_argument('--plots', action="store_true", default=False, help='
 general_group.add_argument('--threads', type=int, default=1, help='number of threads to use [default = %(default)d]')
 general_group.add_argument('--keep', action="store_true", default=False, help='keep large intermediate files [default = off]')
 general_group.add_argument('-h', '--help', action='help', help="show this help message and exit")
-general_group.add_argument('--themisto_index', type=str, help='path to the themisto index directory [default = ref_idx in --ref]')
 
 # set up arg vars
 args=parser.parse_args()
@@ -232,7 +232,7 @@ if mode_run:
                 run_mGEMS(themisto_align_exec, mSWEEP_exec, mGEMS_exec, t, min_abun, rr1, rr2, ref_d, out_dr, binned_reads_d, msweep_abun, keep, themisto_index)
 
                 # check the mGEMS bins
-                check_mGEMS(mash_exec, seqtk_exec, t, ss, min_abun, ref_d, out_dr, binned_reads_d, msweep_abun, themisto_index)
+                check_mGEMS(mash_exec, seqtk_exec, t, ss, min_abun, ref_d, out_dr, binned_reads_d, msweep_abun)
                 
                 if plots:
                     sys.stderr.write("Plotting output...\n")

--- a/get_assignments.py
+++ b/get_assignments.py
@@ -9,10 +9,10 @@ import re
 import pandas as pd
 import numpy as np
 
-def run_mGEMS(themisto_align_exec, mSWEEP_exec, mGEMS_exec, t, min_abun, r1, r2, ref_d, out_d, out_d_bin, msweep_abun, keep):
+def run_mGEMS(themisto_align_exec, mSWEEP_exec, mGEMS_exec, t, min_abun, r1, r2, ref_d, out_d, out_d_bin, msweep_abun, keep, themisto_index):
     sys.stderr.write("Running mSWEEP/mGEMS pipeline on {},{} against reference set {}...\n".format(r1, r2, ref_d))
 
-    ref_idx="{}/ref_idx".format(ref_d)
+    ref_idx=themisto_index
     ref=os.path.basename(ref_d)
     out=os.path.basename(out_d)
     tmp_out_d="{}/tmp".format(out_d)

--- a/reference.py
+++ b/reference.py
@@ -159,7 +159,7 @@ def get_comp(seqtk_exec, in_clu, in_fa, out_file, out_file_summary, seq_info, no
             std_result=subprocess.run(setup_cmd, shell=True, stdout=outfile)
             for i in range(seq_count):
                 assembly=seq_info["assembly"][i]
-                seqtk_cmd="{} comp {} | cut -f2-13".format(seqtk_exec, assembly)
+                seqtk_cmd="{} comp {} | cut -f2-13 | awk '{for(i=1;i<=NF;i++)$i=(a[i]+=$i)}END{print}'".format(seqtk_exec, assembly)
                 std_result=subprocess.run(seqtk_cmd, shell=True, check=True, text=True, stdout=outfile)
     else:
         seqtk_cmd="{} comp {} >> {}".format(seqtk_exec, in_fa, out_file)

--- a/reference.py
+++ b/reference.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from sketch import *
 
-def setup_reference(mash_exec, themisto_build_exec, seqtk_exec, d, t, ss, thr_prop_min, thr_abs_min, thr_prop_exp, redo_thr):
+def setup_reference(mash_exec, themisto_build_exec, seqtk_exec, d, t, ss, thr_prop_min, thr_abs_min, thr_prop_exp, redo_thr, no_build_index):
     sys.stderr.write("Setting up reference set {}...\n".format(d))
 
     seq_info_f="{}/ref_info.tsv".format(d)
@@ -75,22 +75,23 @@ def setup_reference(mash_exec, themisto_build_exec, seqtk_exec, d, t, ss, thr_pr
         
         sys.stderr.write("Calculating thresholds...\n")
         get_thresholds(clu_out, msh_dis_clu_out, thr_prop_min, thr_abs_min, thr_prop_exp, clu_thr_out)
-    
-        idx_d="{}/ref_idx".format(d)
-        idx_d_tmp="{}/ref_idx/tmp".format(d)
 
-        if not os.path.isdir(idx_d):
-            os.makedirs(idx_d)
+        if not no_build_index:
+            idx_d="{}/ref_idx".format(d)
+            idx_d_tmp="{}/ref_idx/tmp".format(d)
+
+            if not os.path.isdir(idx_d):
+                os.makedirs(idx_d)
     
-        if not os.path.isdir(idx_d_tmp):
-            os.makedirs(idx_d_tmp)
+            if not os.path.isdir(idx_d_tmp):
+                os.makedirs(idx_d_tmp)
         
-        sys.stderr.write("Indexing reference set...\n")
-        themisto_cmd="{} --k 31 --n-threads {} --input-file {} --auto-colors --index-dir {} --temp-dir {}".format(themisto_build_exec, t, fa_out, idx_d, idx_d_tmp)
-        std_result=subprocess.run(themisto_cmd, shell=True, check=True, capture_output=True, text=True)
-        log.write("{}\n\n{}\n{}\n\n".format(std_result.args, std_result.stderr, std_result.stdout))
+            sys.stderr.write("Indexing reference set...\n")
+            themisto_cmd="{} --k 31 --n-threads {} --input-file {} --auto-colors --index-dir {} --temp-dir {}".format(themisto_build_exec, t, fa_out, idx_d, idx_d_tmp)
+            std_result=subprocess.run(themisto_cmd, shell=True, check=True, capture_output=True, text=True)
+            log.write("{}\n\n{}\n{}\n\n".format(std_result.args, std_result.stderr, std_result.stdout))
         
-        sys.stderr.write("Reference set {} setup completed\n".format(d))
+            sys.stderr.write("Reference set {} setup completed\n".format(d))
 
         log.close()
 

--- a/reference.py
+++ b/reference.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from sketch import *
 
-def setup_reference(mash_exec, themisto_build_exec, seqtk_exec, d, t, ss, thr_prop_min, thr_abs_min, thr_prop_exp, redo_thr, no_build_index):
+def setup_reference(mash_exec, themisto_build_exec, seqtk_exec, d, t, ss, thr_prop_min, thr_abs_min, thr_prop_exp, redo_thr, no_build_index, no_build_fasta):
     sys.stderr.write("Setting up reference set {}...\n".format(d))
 
     seq_info_f="{}/ref_info.tsv".format(d)
@@ -27,6 +27,7 @@ def setup_reference(mash_exec, themisto_build_exec, seqtk_exec, d, t, ss, thr_pr
     clu_out="{}/ref_clu.tsv".format(d)
     comp_out="{}/ref_comp.tsv".format(d)
     clu_comp_out="{}/ref_clu_comp.tsv".format(d)
+    paths_out="{}/ref_paths.txt".format(d)
 
     if redo_thr == True:
         
@@ -36,37 +37,45 @@ def setup_reference(mash_exec, themisto_build_exec, seqtk_exec, d, t, ss, thr_pr
     else:
         log=open("{}/ref.log".format(d), 'w')
         
-        sys.stderr.write("Creating multifasta...\n")
-        fo=gzip.open(fa_out, 'wt')
-        for i in range(seq_count):
-            seq_id=seq_info["id"][i]
-            cluster=seq_info["cluster"][i]
-            assembly=seq_info["assembly"][i]
+        if not no_build_fasta:
+            sys.stderr.write("Creating multifasta...\n")
+            fo=gzip.open(fa_out, 'wt')
+            for i in range(seq_count):
+                seq_id=seq_info["id"][i]
+                cluster=seq_info["cluster"][i]
+                assembly=seq_info["assembly"][i]
 
-            fo.write(">{}\n".format(seq_id))
-            
-            if assembly.endswith('.gz'):
-                f_tmp=gzip.open(assembly, 'rt')
-            else:
-                f_tmp=open(assembly, 'r')
-            for l in f_tmp:
-                if not re.match(r'^>', l):
-                    fo.write(l)
-            f_tmp.close()
-        fo.close()
+                fo.write(">{}\n".format(seq_id))
+
+                if assembly.endswith('.gz'):
+                    f_tmp=gzip.open(assembly, 'rt')
+                else:
+                    f_tmp=open(assembly, 'r')
+                    for l in f_tmp:
+                        if not re.match(r'^>', l):
+                            fo.write(l)
+                    f_tmp.close()
+            fo.close()
 
         clu_m=seq_info[["cluster"]]
         clu_m.to_csv(clu_out_m, sep="\t", index=False, header=None)
 
         clu=seq_info[["id", "cluster"]]
         clu.to_csv(clu_out, sep="\t", index=False)
-        
-        get_comp(seqtk_exec, clu_out, fa_out, comp_out, clu_comp_out)
+
+        paths=seq_info[["assembly"]]
+        paths.to_csv(paths_out, sep="\t", index=False, header=False)
+
+        get_comp(seqtk_exec, clu_out, fa_out, comp_out, clu_comp_out, seq_info, no_build_fasta)
 
         sys.stderr.write("Creating mash sketches...\n")
-        std_result=run_mash_sketch(mash_exec, t, fa_out, msh_out, ss, m=None, in_type="fa")
-        log.write("{}\n\n{}\n{}\n\n".format(std_result.args, std_result.stderr, std_result.stdout))
-        
+        if not no_build_fasta:
+            std_result=run_mash_sketch(mash_exec, t, fa_out, msh_out, ss, m=None, in_type="fa")
+            log.write("{}\n\n{}\n{}\n\n".format(std_result.args, std_result.stderr, std_result.stdout))
+        else:
+            std_result=run_mash_sketch(mash_exec, t, paths_out, msh_out, ss, m=None, in_type="list")
+            log.write("{}\n\n{}\n{}\n\n".format(std_result.args, std_result.stderr, std_result.stdout))
+
         sys.stderr.write("Calculating mash distances...\n")
         std_result=run_mash_dist(mash_exec, t, msh_out, msh_out, msh_dis_out)
         log.write("{}\n\n{}\n{}\n\n".format(std_result.args, std_result.stderr, std_result.stdout))
@@ -138,16 +147,27 @@ def get_thresholds(in_clu, in_dis, thr_prop_min, thr_abs_min, thr_prop_exp, out_
 
     t_summary.to_csv(out_file, sep="\t", index=False)
 
-def get_comp(seqtk_exec, in_clu, in_fa, out_file, out_file_summary):
+def get_comp(seqtk_exec, in_clu, in_fa, out_file, out_file_summary, seq_info, no_build_fasta):
     
     clu=pd.read_csv(in_clu, sep="\t", dtype={'id': 'str'})
     
-    setup_cmd="echo \"id\tlength\t#A\t#C\t#G\t#T\t#2\t#3\t#4\t#CpG\t#tv\t#ts\t#CpG-ts\" > {}".format(out_file)
-    std_result=subprocess.run(setup_cmd, shell=True, check=True, capture_output=True, text=True)
-    seqtk_cmd="{} comp {} >> {}".format(seqtk_exec, in_fa, out_file)
-    std_result=subprocess.run(seqtk_cmd, shell=True, check=True, capture_output=True, text=True)
+
+    if no_build_fasta:
+        seq_count=len(seq_info)
+        with open(out_file, "w") as outfile:
+            setup_cmd="echo \"length\t#A\t#C\t#G\t#T\t#2\t#3\t#4\t#CpG\t#tv\t#ts\t#CpG-ts\""
+            std_result=subprocess.run(setup_cmd, shell=True, stdout=outfile)
+            for i in range(seq_count):
+                assembly=seq_info["assembly"][i]
+                seqtk_cmd="{} comp {} | cut -f2-13".format(seqtk_exec, assembly)
+                std_result=subprocess.run(seqtk_cmd, shell=True, check=True, text=True, stdout=outfile)
+    else:
+        seqtk_cmd="{} comp {} >> {}".format(seqtk_exec, in_fa, out_file)
+        std_result=subprocess.run(seqtk_cmd, shell=True, check=True, capture_output=True, text=True)
 
     lens=pd.read_csv(out_file, sep="\t", dtype={'id': 'str'})
+    lens[["id"]] = seq_info[["id"]]
+    lens.to_csv(out_file, sep='\t', index=False)
     lens=lens[["id", "length"]]
 
     clu_lens=clu.merge(lens, how="left", on="id")

--- a/sketch.py
+++ b/sketch.py
@@ -34,6 +34,9 @@ def run_mash_sketch(mash_exec, t, in_file, out_file, ss, m, in_type):
     elif in_type == "fq":
         mash_cmd="{} sketch -p {} -s {} -r -m {} -I {} -C - -o {} {}".format(mash_exec, t, ss, m, seq_id, out_file_p, in_file)
         std_result=subprocess.run(mash_cmd, shell=True, check=True, capture_output=True, text=True)
+    elif in_type == "list":
+        mash_cmd="{} sketch -p {} -s {} -l -o {} {}".format(mash_exec, t, ss, out_file_p, in_file)
+        std_result=subprocess.run(mash_cmd, shell=True, check=True, capture_output=True, text=True)
     
     return(std_result)
 
@@ -79,6 +82,12 @@ def add_clusters(in_clu, in_dis, out_file, ref=False, met=False):
     clu=pd.read_csv(in_clu, sep="\t", dtype={'id': 'str'})
     
     data=pd.read_csv(in_dis, sep="\t", dtype={'ref_id': 'str', 'met_id': 'str'})
+
+    data["ref_id"] = data["ref_id"].apply(os.path.basename)
+    data["ref_id"] = data["ref_id"].apply(lambda x : os.path.splitext(x)[0])
+    data["met_id"] = data["met_id"].apply(os.path.basename)
+    data["met_id"] = data["met_id"].apply(lambda x : os.path.splitext(x)[0])
+
     if ref == True:
         data=data.merge(clu, how="left", left_on="ref_id", right_on="id")
         data=data.rename(columns={"cluster":"ref_cluster"})


### PR DESCRIPTION
Hi,

This pull request adds some features that I found useful when running your tool:
- `--no_build_index` toggle to --mode_setup which tells the setup to skip building the themisto index.
- `--themisto_index` argument to --mode_run which passes a prebuilt index (i.e. if --no_build_index was used in the setup call) to run_mGEMS().

Neither option _should_ break any backwards compatibility but I only tested this on my own use-cases and not exhaustively.

I also added some documentation to README.md on how to use conda for installing some of the dependencies. I fixed version numbers in the instructions just to make sure they don't cause any compatibility issues in the future if they receive major updates.

Thanks for improving the usability of mSWEEP & mGEMS :)